### PR TITLE
update to stable Dart FFI

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -9,7 +9,7 @@ void main() {
   ao.initialize();
 
   final driverId = ao.defaultDriverId();
-  
+
   print(ao.driverInfo(driverId));
 
   const bits = 16;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
-  ffi: ^0.1.3
+  ffi: ^1.1.2
 
 dev_dependencies:
   test: ^1.9.2


### PR DESCRIPTION
This fixes usage of Dart FFI in curretn Dart 2.13 stable, where there were breaking changes that have been made since this package was published.

Tested with just the example `main.dart` as working on `Ubuntu 21.04` which comes pre-installed with libao 4.1.1.

Fixes: #1 